### PR TITLE
Removing laggy print statement in client.lua

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -91,7 +91,8 @@ Citizen.CreateThread(function()
         end
 		if not (hideAll) then
 			for _, id in ipairs(GetActivePlayers()) do
-				print("The server ID of player " .. GetPlayerName(id) .. " is: " .. GetPlayerServerId(id))
+				-- Removing print statement that spams F8 console and lags some players.
+				-- print("The server ID of player " .. GetPlayerName(id) .. " is: " .. GetPlayerServerId(id))
 				local activeTag = activeTagTracker[GetPlayerServerId(id)]
 				if activeTag == nil then 
 					activeTag = ''


### PR DESCRIPTION
This print statement constantly spams the F8 console and causes lag to some players around 5-24 fps lost.